### PR TITLE
Restyle certification badges for responsive layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,31 @@
     <img
       src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=26&duration=2200&pause=800&color=FF3131&center=true&vCenter=true&width=900&height=48&lines=%5BALERT%5D%20ACCESS%20GRANTED%20%E2%96%B2;It%27s%20me%20Vijay%20%7C%20Cybersecurity%20Engineer;Cloud%20Security%20%7C%20SIEM%20%26%20IR;Security%2B%20%26%20CCNA%20%7C%20OSCP%20%26%20CISSP%20(in%20progress)"
       alt="[ALERT] ACCESS GRANTED ▲ | It's me Vijay | Cybersecurity Engineer | Cloud Security | SIEM & IR | Security+ & CCNA | OSCP & CISSP (in progress)"
+      width="900"
+      style="max-width: 100%; height: auto;"
     />
   </a>
 </p>
 
 ## 🌟 Skills
-<table align="left" border="0" cellpadding="0" cellspacing="8">
-  <tr>
-    <td align="center" valign="middle"><img src="https://cdn.simpleicons.org/wireshark/167f92" width="36" alt="Wireshark" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="36" alt="Python" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/bash/bash-original.svg" width="36" alt="Bash" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="36" alt="JavaScript" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="36" alt="TypeScript" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="36" alt="Git" loading="lazy"></td>
-  </tr>
-  <tr>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg" width="36" alt="Docker" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/jenkins/jenkins-original.svg" width="36" alt="Jenkins" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-original.svg" width="36" alt="Linux" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://raw.githubusercontent.com/tandpfun/skill-icons/main/icons/AWS-Dark.svg" width="36" alt="AWS" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://raw.githubusercontent.com/tandpfun/skill-icons/main/icons/Azure-Dark.svg" width="36" alt="Azure" loading="lazy"></td>
-    <td align="center" valign="middle"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/googlecloud/googlecloud-original.svg" width="36" alt="Google Cloud" loading="lazy"></td>
-  </tr>
-</table>
-
-<br clear="both" />
+<div align="center">
+  <p>
+    <img src="https://cdn.simpleicons.org/wireshark/167f92" width="48" alt="Wireshark" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="48" alt="Python" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/bash/bash-original.svg" width="48" alt="Bash" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="48" alt="JavaScript" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="48" alt="TypeScript" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" width="48" alt="Git" loading="lazy" style="margin: 6px;" />
+  </p>
+  <p>
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg" width="48" alt="Docker" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/jenkins/jenkins-original.svg" width="48" alt="Jenkins" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-original.svg" width="48" alt="Linux" loading="lazy" style="margin: 6px;" />
+    <img src="https://raw.githubusercontent.com/tandpfun/skill-icons/main/icons/AWS-Dark.svg" width="48" alt="AWS" loading="lazy" style="margin: 6px;" />
+    <img src="https://raw.githubusercontent.com/tandpfun/skill-icons/main/icons/Azure-Dark.svg" width="48" alt="Azure" loading="lazy" style="margin: 6px;" />
+    <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/googlecloud/googlecloud-original.svg" width="48" alt="Google Cloud" loading="lazy" style="margin: 6px;" />
+  </p>
+</div>
 
 
 ## 📫 Connect with Me
@@ -52,16 +52,44 @@
     width="420"
     alt="Top Languages (GitHub Readme Stats)"
     loading="lazy"
+    style="max-width: 100%; height: auto;"
   />
 </p>
 
 ## 🎓 Certifications
 
-<p align="left">
-  <a href="https://www.credly.com/badges/ca0a4bbf-50a4-41a0-b105-3ea645347a7f/public_url" target="_blank">
-    <img src="https://img.shields.io/badge/COMPTIA%20SECURITY%2B-FF0000?style=for-the-badge&logo=comptia&logoColor=white" alt="CompTIA Security+" />
+<div
+  align="center"
+  style="display: flex; flex-wrap: wrap; gap: 16px; justify-content: center; padding: 0 12px;"
+>
+  <a
+    href="https://www.credly.com/badges/ca0a4bbf-50a4-41a0-b105-3ea645347a7f/public_url"
+    target="_blank"
+    style="display: inline-flex; align-items: center; gap: 12px; padding: 14px 22px; border-radius: 999px; background: linear-gradient(135deg, #ff5858, #f09819); color: #ffffff; font-weight: 600; text-decoration: none; box-shadow: 0 12px 24px rgba(240, 152, 25, 0.25); min-width: 260px; justify-content: center; transition: transform 0.2s ease, box-shadow 0.2s ease;"
+  >
+    <img
+      src="https://images.credly.com/images/6837ab7d-603e-4727-bb0a-0baadfb1f3d3/securityplusce-certification-badge.png"
+      alt="CompTIA Security+"
+      width="40"
+      height="40"
+      loading="lazy"
+      style="border-radius: 50%; background: rgba(255, 255, 255, 0.9); padding: 6px;"
+    />
+    <span>CompTIA Security+</span>
   </a>
-  <a href="https://www.credly.com/badges/6904480e-3484-456e-a1e1-8095b7b4ae76/public_url" target="_blank">
-    <img src="https://img.shields.io/badge/CCNA-1BA0D7?style=for-the-badge&logo=cisco&logoColor=white" alt="Cisco Certified Network Associate (CCNA)" />
+  <a
+    href="https://www.credly.com/badges/6904480e-3484-456e-a1e1-8095b7b4ae76/public_url"
+    target="_blank"
+    style="display: inline-flex; align-items: center; gap: 12px; padding: 14px 22px; border-radius: 999px; background: linear-gradient(135deg, #1ba0d7, #1372bd); color: #ffffff; font-weight: 600; text-decoration: none; box-shadow: 0 12px 24px rgba(19, 114, 189, 0.25); min-width: 260px; justify-content: center; transition: transform 0.2s ease, box-shadow 0.2s ease;"
+  >
+    <img
+      src="https://images.credly.com/images/a3fa45b3-5c83-41f5-988f-31f3b6b5b4d8/Cisco_CCNA.png"
+      alt="Cisco Certified Network Associate"
+      width="40"
+      height="40"
+      loading="lazy"
+      style="border-radius: 50%; background: rgba(255, 255, 255, 0.9); padding: 6px;"
+    />
+    <span>Cisco Certified Network Associate</span>
   </a>
-</p>
+</div>


### PR DESCRIPTION
## Summary
- make the hero typing banner scale down on smaller viewports
- replace the skills table with a wrapping icon layout for better responsiveness
- ensure the top languages card resizes fluidly within the README
- restyle the certification buttons with rounded pill layout that adapts responsively

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efdb4eb1c8832a81d6cf29b121cb0c